### PR TITLE
Refresh the OAuth token on 401 instead of on an expiry timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.9.1
+
+- Refresh the OAuth access token when Zendesk rejects it with a 401,
+  rather than proactively on an expiry timer.
+
 ## 2.9.0
 
 - Add OAuth support.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     # Basic package information.
     name="zdesk",
     author="Brent Woodruff",
-    version="2.9.0",
+    version="2.9.1",
     author_email="brent@fprimex.com",
     packages=["zdesk"],
     include_package_data=True,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -41,14 +41,6 @@ class TestFetchOauthToken:
 
         assert result == TOKEN_RESPONSE
 
-    def test_returns_expires_in(self):
-        zd = Zendesk(ZDESK_URL)
-        zd.client.post = MagicMock(return_value=_mock_token_response())
-
-        result = zd.fetch_oauth_token(CLIENT_ID, CLIENT_SECRET)
-
-        assert 'expires_in' in result
-
     def test_posts_correct_payload_to_oauth_tokens_endpoint(self):
         zd = Zendesk(ZDESK_URL)
         zd.client.post = MagicMock(return_value=_mock_token_response())
@@ -86,59 +78,86 @@ class TestFetchOauthToken:
         assert zd.client.auth is None
 
 
-class TestTokenRefresh:
-    def test_call_refreshes_when_token_expired(self):
+def _api_response(status_code=200):
+    return MagicMock(status_code=status_code, headers={}, content=b'')
+
+
+class TestTokenRefreshOn401:
+    def _oauth_client(self):
         zd = Zendesk(ZDESK_URL)
         zd.client.post = MagicMock(return_value=_mock_token_response())
         zd.fetch_oauth_token(CLIENT_ID, CLIENT_SECRET)
+        return zd
 
-        # Force the token to look expired.
-        zd._oauth_expires_at = 0
+    def test_refreshes_token_when_request_returns_401(self):
+        zd = self._oauth_client()
         zd.client.request = MagicMock(
-            return_value=MagicMock(status_code=200, headers={}, content=b''))
+            side_effect=[_api_response(401), _api_response(200)])
 
         zd.call('/api/v2/tickets.json')
 
-        # One initial fetch plus one refresh triggered by the expired token.
+        # One initial fetch plus one refresh triggered by the 401.
         assert zd.client.post.call_count == 2
 
-    def test_call_does_not_refresh_when_token_valid(self):
-        zd = Zendesk(ZDESK_URL)
-        zd.client.post = MagicMock(return_value=_mock_token_response())
-        zd.fetch_oauth_token(CLIENT_ID, CLIENT_SECRET)
-
+    def test_replays_the_request_after_refreshing(self):
+        zd = self._oauth_client()
         zd.client.request = MagicMock(
-            return_value=MagicMock(status_code=200, headers={}, content=b''))
+            side_effect=[_api_response(401), _api_response(200)])
 
         zd.call('/api/v2/tickets.json')
 
-        # Only the initial fetch; the token is still well within its lifetime.
+        assert zd.client.request.call_count == 2
+
+    def test_replay_uses_the_refreshed_token(self):
+        zd = self._oauth_client()
+        refreshed = {'access_token': 'refreshed_token', 'token_type': 'bearer'}
+        zd.client.post = MagicMock(
+            return_value=_mock_token_response(json_data=refreshed))
+        zd.client.request = MagicMock(
+            side_effect=[_api_response(401), _api_response(200)])
+
+        zd.call('/api/v2/tickets.json')
+
+        headers = zd.client.request.call_args.kwargs['headers']
+        assert headers['Authorization'] == 'Bearer refreshed_token'
+
+    def test_raises_when_the_replay_is_also_rejected(self):
+        zd = self._oauth_client()
+        zd.client.request = MagicMock(
+            side_effect=[_api_response(401), _api_response(401)])
+
+        with pytest.raises(AuthenticationError):
+            zd.call('/api/v2/tickets.json')
+
+        # Refreshed once; the second 401 is a genuine credential failure.
+        assert zd.client.post.call_count == 2
+
+    def test_does_not_refresh_when_the_request_succeeds(self):
+        zd = self._oauth_client()
+        zd.client.request = MagicMock(return_value=_api_response(200))
+
+        zd.call('/api/v2/tickets.json')
+
         assert zd.client.post.call_count == 1
 
-    def test_no_refresh_when_expires_in_absent(self):
-        zd = Zendesk(ZDESK_URL)
-        no_expiry = {'access_token': ACCESS_TOKEN, 'token_type': 'bearer'}
-        zd.client.post = MagicMock(
-            return_value=_mock_token_response(json_data=no_expiry))
-        zd.fetch_oauth_token(CLIENT_ID, CLIENT_SECRET)
+    def test_does_not_refresh_before_the_token_expires(self):
+        zd = self._oauth_client()
+        zd.client.request = MagicMock(return_value=_api_response(200))
 
-        assert zd._oauth_expires_at is None
+        for _ in range(3):
+            zd.call('/api/v2/tickets.json')
 
-        zd.client.request = MagicMock(
-            return_value=MagicMock(status_code=200, headers={}, content=b''))
-        zd.call('/api/v2/tickets.json')
-
-        # Non-expiring token is never proactively refreshed.
+        # Tokens are used until Zendesk rejects them, not renewed on a clock.
         assert zd.client.post.call_count == 1
 
     def test_no_refresh_for_non_oauth_auth(self):
         zd = Zendesk(ZDESK_URL, zdesk_email='user@example.com',
                      zdesk_api='api_token')
         zd.client.post = MagicMock()
-        zd.client.request = MagicMock(
-            return_value=MagicMock(status_code=200, headers={}, content=b''))
+        zd.client.request = MagicMock(return_value=_api_response(401))
 
-        zd.call('/api/v2/tickets.json')
+        with pytest.raises(AuthenticationError):
+            zd.call('/api/v2/tickets.json')
 
         zd.client.post.assert_not_called()
 

--- a/zdesk/zdesk.py
+++ b/zdesk/zdesk.py
@@ -161,11 +161,10 @@ class Zendesk(ZendeskAPI):
         self.retry_on = retry_on
         self.max_retries = max_retries
 
-        # OAuth credentials and token expiry, used to refresh the access
-        # token before it lapses. Populated by fetch_oauth_token.
+        # OAuth credentials, retained so an expired access token can be
+        # re-fetched. Populated by fetch_oauth_token.
         self._oauth_client_id = None
         self._oauth_client_secret = None
-        self._oauth_expires_at = None
 
         if use_oauth:
             if not (client_id and client_secret):
@@ -183,8 +182,8 @@ class Zendesk(ZendeskAPI):
         client_id - OAuth application client ID
         client_secret - OAuth application client secret
 
-        Returns the full token response dict, including access_token,
-        token_type, and expires_in (seconds until expiration).
+        Returns the full token response dict, including access_token
+        and token_type.
 
         Raises AuthenticationError on failure.
         """
@@ -203,34 +202,12 @@ class Zendesk(ZendeskAPI):
         token_data = response.json()
         self.zdesk_oauth = token_data['access_token']
 
-        # Retain credentials so the token can be transparently refreshed
-        # once it expires. expires_in is optional per the OAuth spec; if it
-        # is absent we treat the token as non-expiring.
+        # Retain credentials so the token can be transparently re-fetched
+        # when Zendesk rejects it as expired.
         self._oauth_client_id = client_id
         self._oauth_client_secret = client_secret
-        expires_in = token_data.get('expires_in')
-        if expires_in is not None:
-            self._oauth_expires_at = time.time() + expires_in
-        else:
-            self._oauth_expires_at = None
 
         return token_data
-
-    def _refresh_oauth_token_if_needed(self):
-        """Re-fetch the OAuth token if it is expired or about to expire.
-
-        No-op unless authenticating via OAuth with a known expiry. A 60
-        second buffer avoids using a token that lapses mid-request.
-        """
-        if not (self._oauth_client_id and self._oauth_client_secret):
-            return
-        if self._oauth_expires_at is None:
-            return
-        if time.time() < self._oauth_expires_at - 60:
-            return
-
-        self.fetch_oauth_token(
-            self._oauth_client_id, self._oauth_client_secret)
 
     def _update_auth(self):
         if self._zdesk_oauth:
@@ -422,10 +399,6 @@ class Zendesk(ZendeskAPI):
             to determine an appropriate value to return is used.
         """
 
-        # Ensure the OAuth access token is still valid before we build and
-        # send the request. No-op for non-OAuth or non-expiring tokens.
-        self._refresh_oauth_token_if_needed()
-
         # Rather obscure way to support retry_on per single API call
         if retry_on and max_retries:
             try:
@@ -492,6 +465,7 @@ class Zendesk(ZendeskAPI):
         results = []
         all_requests_complete = False
         request_count = 0
+        oauth_token_refreshed = False
 
         while not all_requests_complete:
             # Make an http request
@@ -522,6 +496,17 @@ class Zendesk(ZendeskAPI):
             # error and raise proper exception
 
             code = response.status_code
+
+            # An expired OAuth access token comes back as a 401. Fetch a
+            # fresh one and replay the request; a second 401 means the
+            # credentials themselves are bad, so let it raise.
+            if (code == 401 and self._oauth_client_id and
+                    not oauth_token_refreshed):
+                oauth_token_refreshed = True
+                self.fetch_oauth_token(self._oauth_client_id,
+                                       self._oauth_client_secret)
+                continue
+
             try:
                 if not 200 <= code < 300:
                     partial_results = self._combine_results(results) if results else None


### PR DESCRIPTION
Refreshes the OAuth access token when Zendesk rejects it with a 401, instead of proactively on an expiry timer.

2.9.0 tracked `expires_in` and re-fetched the token 60s before it lapsed, checking on every `call()`. This replaces that with a one-shot reactive refresh: on a 401, fetch a fresh token and replay the request once. A second 401 means the credentials themselves are bad and raises `AuthenticationError`, as before. Non-OAuth clients are unaffected — the refresh is guarded on retained OAuth credentials.

`fetch_oauth_token()` assigns `self.zdesk_oauth`, whose setter calls `_update_auth()`, so the replayed request picks up the new bearer header automatically. The refresh flag is per-`call()`, so a request can never loop on repeated 401s.

## Changes

- Remove `_refresh_oauth_token_if_needed()`, `_oauth_expires_at`, and the `expires_in` bookkeeping in `fetch_oauth_token()`. `fetch_oauth_token()` still returns the full token response; it just no longer reads `expires_in`.
- Remove the proactive refresh call at the top of `call()`; add the 401 refresh-and-replay inside the request loop.
- Replace `TestTokenRefresh` with `TestTokenRefreshOn401`: refreshes on 401, replays the request, replay uses the new token, raises when the replay is also rejected, no refresh on success, no refresh across repeated calls, no refresh for non-OAuth auth.
- Bump to 2.9.1 — deliberately not a retag of 2.9.0, since `roverdotcom/web`'s `uv.lock` pins that sdist by sha256.
